### PR TITLE
提交

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 2.8)
 project(resize)
-add_compile_options(-O3)
+add_compile_options(-O3 -std=c++17)
 add_executable(resize main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_D
 string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
-add_compile_options(-O3 -std=c++17 -march=native)
+add_compile_options(-O3 -std=c++17 -march=native -fopenmp)
+add_link_options(-fopenmp)
 
 add_executable(resize main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 project(resize)
-add_compile_options(-O3 -std=c++17)
+
+string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+
+set(CMAKE_CXX_FLAGS "-O3 -std=c++17 -march=native")
+
 add_executable(resize main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_D
 string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 string(REGEX REPLACE "(-O[0123s])" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
-set(CMAKE_CXX_FLAGS "-O3 -std=c++17 -march=native")
+add_compile_options(-O3 -std=c++17 -march=native)
 
 add_executable(resize main.cpp)

--- a/resize.hpp
+++ b/resize.hpp
@@ -235,10 +235,11 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
             {
                 constexpr auto j = 3;
 
-                const auto xdw0 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c + j - 1)) * kNChannel]);
-                const auto xdw1 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c + j - 1)) * kNChannel]);
-                const auto xdw2 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c + j - 1)) * kNChannel]);
-                const auto xdw3 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c + j - 1)) * kNChannel]);
+                __m128 xdw0, xdw1, xdw2, xdw3;
+                LoadXmm(xdw0, &src.data[((r - 1) * nCol + (c + j - 1)) * kNChannel]);
+                LoadXmm(xdw1, &src.data[((r - 0) * nCol + (c + j - 1)) * kNChannel]);
+                LoadXmm(xdw2, &src.data[((r + 1) * nCol + (c + j - 1)) * kNChannel]);
+                LoadXmm(xdw3, &src.data[((r + 2) * nCol + (c + j - 1)) * kNChannel]);
                 const auto xf0 = _mm_cvtepi32_ps(xdw0);
                 const auto xf1 = _mm_cvtepi32_ps(xdw1);
                 const auto xf2 = _mm_cvtepi32_ps(xdw2);

--- a/resize.hpp
+++ b/resize.hpp
@@ -175,8 +175,8 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
         {
             PROF_SCOPED_MARKER("LoadInput");
         #if USE_ASM_LOAD
-            #define LoadYmm(y, p) asm("vpmovzxbd %1, %0" : "=x"(y), "m"(*(unsigned char(*)[8])(p)))
-            #define LoadXmm(x, p) asm("vpmovzxbd %1, %0" : "=x"(x), "m"(*(unsigned char(*)[4])(p)))
+            #define LoadYmm(y, p) asm("vpmovzxbd %1, %0" : "=x"(y) : "m"(*(unsigned char(*)[8])(p)))
+            #define LoadXmm(x, p) asm("vpmovzxbd %1, %0" : "=x"(x) : "m"(*(unsigned char(*)[4])(p)))
         #else
             #define LoadYmm(y, p) (y = _mm256_cvtepu8_epi32(*(const __m128i*)(p)));
             #define LoadXmm(x, p) (x = _mm_cvtepu8_epi32(   *(const __m128i*)(p)))

--- a/resize.hpp
+++ b/resize.hpp
@@ -91,6 +91,11 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
     {
         for (auto c = 1; c < nCol - 2; ++c)
         {
+            float in[4][4][3];
+            for (auto i = 0; i < 4; ++i)
+                for (auto j = 0; j < 4; ++j)
+                    for (auto ch = 0; ch < kNChannel; ++ch)
+                        in[i][j][ch] = src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
         #if SIMPLIFY_START
             for (auto ir = 0; ir < kRatio; ++ir)
         #else
@@ -115,7 +120,7 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
                     for (auto i = 0; i < 4; ++i)
                         for (auto j = 0; j < 4; ++j)
                             for (auto ch = 0; ch < kNChannel; ++ch)
-                                sums[ch] += coeffs[i][j] * src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
+                                sums[ch] += coeffs[i][j] * in[i][j][ch];
                     for (int ch = 0; ch < kNChannel; ++ch)
                         pRes[((r * kRatio + ir) * nResCol + (c * kRatio + ic)) * kNChannel + ch] = static_cast<unsigned char>(sums[ch]);
                 }

--- a/resize.hpp
+++ b/resize.hpp
@@ -89,13 +89,13 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
 
     for (auto r = 1; r < nRow - 2; ++r)
     {
-    #if SIMPLIFY_START
-        for (auto ir = 0; ir < kRatio; ++ir)
-    #else
-        for (auto ir = r == 1 ? 1 : 0; ir < kRatio; ++ir)
-    #endif
+        for (auto c = 1; c < nCol - 2; ++c)
         {
-            for (auto c = 1; c < nCol - 2; ++c)
+        #if SIMPLIFY_START
+            for (auto ir = 0; ir < kRatio; ++ir)
+        #else
+            for (auto ir = r == 1 ? 1 : 0; ir < kRatio; ++ir)
+        #endif
             {
             #if SIMPLIFY_START
                 for (auto ic = 0; ic < kRatio; ++ic)

--- a/resize.hpp
+++ b/resize.hpp
@@ -119,15 +119,17 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
                     const auto y = float(c * kRatio + ic) / kRatioFloat;
                     CalcCoeff4x4(x - floor(x), y - floor(y), coeffs);
                 #endif
-                    for (int ch = 0; ch < kNChannel; ++ch)
+                    const auto* pInInnerRow = pIn;
+                    float sums[kNChannel]{};
+                    for (auto i = 0; i < 4; ++i, pInInnerRow += nCol * kNChannel)
                     {
-                        auto sum = 0.0f;
-                        const auto* pInner = &pIn[ch];
-                        for (auto i = 0; i < 4; ++i, pInner += nCol * kNChannel)
-                            for (auto j = 0; j < 4; ++j)
-                                sum += coeffs[i][j] * pInner[j * kNChannel];
-                        pOut[ch] = static_cast<unsigned char>(sum);
+                        const auto* pInInner = pInInnerRow;
+                        for (auto j = 0; j < 4; ++j, pInInner += kNChannel)
+                            for (auto ch = 0; ch < kNChannel; ++ch)
+                                sums[ch] += coeffs[i][j] * pInInner[ch];
                     }
+                    for (int ch = 0; ch < kNChannel; ++ch)
+                        pOut[ch] = static_cast<unsigned char>(sums[ch]);
                 }
             }
         }

--- a/resize.hpp
+++ b/resize.hpp
@@ -186,19 +186,21 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
             PROF_SCOPED_MARKER("LoadInput");
         #if LOAD_IN_INTRIN
             #if LOAD_IN_YMM
-                const auto ydw00 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw01 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 8]);
-                const auto ydw10 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw11 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 8]);
-                const auto ydw20 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw21 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 8]);
-                const auto ydw30 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw31 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 8]);
+                //const auto ydw00 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 0]);
+                //const auto xdw01 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 8]);
+                //const auto ydw10 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 0]);
+                //const auto xdw11 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 8]);
+                //const auto ydw20 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 0]);
+                //const auto xdw21 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 8]);
+                //const auto ydw30 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 0]);
+                //const auto xdw31 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 8]);
 
                 #define GET_SW0(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_1, _0, _2, _1, _0, _2, _1, _0))
                 #define GET_SW1(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_0, _2, _1, _0, _2, _1, _0, _2))
 
                 #define MAKE_SW(i) \
+                    const auto ydw##i##0 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + i - 1) * nCol + (1 - 1)) * kNChannel + 0]); \
+                    const auto xdw##i##1 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + i - 1) * nCol + (1 - 1)) * kNChannel + 8]); \
                     const auto yf##i##0 = _mm256_cvtepi32_ps(ydw##i##0);                      /* 00 01 02 10 11 12 20 21 */ \
                     const auto yf##i##1 = _mm256_castps128_ps256(_mm_cvtepi32_ps(xdw##i##1)); /* 22 30 31 32 ?? ?? ?? ?? */ \
                     const auto yf##i##2 = _mm256_blend_ps(yf##i##0, yf##i##1, 0b00001111);    /* 22 ?? ?? ?? ?? ?? 20 21 */ \
@@ -310,15 +312,17 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
             #if ROTATE_DELTA
                 const auto j_ = (c + 2) & 3;
                 #if LOAD_ROTATE_DELTA_INTRIN
-                    const auto xdw0 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c + j - 1)) * kNChannel]);
-                    const auto xdw1 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c + j - 1)) * kNChannel]);
-                    const auto xdw2 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c + j - 1)) * kNChannel]);
-                    const auto xdw3 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c + j - 1)) * kNChannel]);
-                    const auto xf0 = _mm_cvtepi32_ps(xdw0);
-                    const auto xf1 = _mm_cvtepi32_ps(xdw1);
-                    const auto xf2 = _mm_cvtepi32_ps(xdw2);
-                    const auto xf3 = _mm_cvtepi32_ps(xdw3);
+                    //const auto xdw0 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c + j - 1)) * kNChannel]);
+                    //const auto xdw1 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c + j - 1)) * kNChannel]);
+                    //const auto xdw2 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c + j - 1)) * kNChannel]);
+                    //const auto xdw3 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c + j - 1)) * kNChannel]);
+                    //const auto xf0 = _mm_cvtepi32_ps(xdw0);
+                    //const auto xf1 = _mm_cvtepi32_ps(xdw1);
+                    //const auto xf2 = _mm_cvtepi32_ps(xdw2);
+                    //const auto xf3 = _mm_cvtepi32_ps(xdw3);
                     #define MAKE_SW(i) \
+                        const auto xdw##i = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel]); \
+                        const auto xf0##i = _mm_cvtepi32_ps(xdw0); \
                         const auto xsw##i##0 = _mm_permute_ps(xf##i, _MM_SHUFFLE(0, 2, 1, 0)); /* 00 01 02 00 */ \
                         const auto xsw##i##1 = _mm_permute_ps(xf##i, _MM_SHUFFLE(1, 0, 2, 1)); /* 01 02 00 01 */ \
                         const auto xsw##i##2 = _mm_permute_ps(xf##i, _MM_SHUFFLE(2, 1, 0, 2)); /* 02 00 01 02 */ \

--- a/resize.hpp
+++ b/resize.hpp
@@ -87,28 +87,20 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
 #define PRECOMPUTE_COEFFS 1
 #define SIMPLIFY_START 0
 
-    const auto* pInRow = src.data;
-#if SIMPLIFY_START
-    auto* pOutRow = &pRes[(kRatio * nResCol + kRatio) * kNChannel];
-#else
-    auto* pOutRow = &pRes[((kRatio + 1) * nResCol + kRatio + 1) * kNChannel];
-#endif
-    for (auto r = 1; r < nRow - 2; ++r, pInRow += nCol * kNChannel)
+    for (auto r = 1; r < nRow - 2; ++r)
     {
     #if SIMPLIFY_START
-        for (auto ir = 0; ir < kRatio; ++ir, pOutRow += nResCol * kNChannel)
+        for (auto ir = 0; ir < kRatio; ++ir)
     #else
-        for (auto ir = r == 1 ? 1 : 0; ir < kRatio; ++ir, pOutRow += nResCol * kNChannel)
+        for (auto ir = r == 1 ? 1 : 0; ir < kRatio; ++ir)
     #endif
         {
-            const auto* pIn = pInRow;
-            auto* pOut = pOutRow;
-            for (auto c = 1; c < nCol - 2; ++c, pIn += kNChannel)
+            for (auto c = 1; c < nCol - 2; ++c)
             {
             #if SIMPLIFY_START
-                for (auto ic = 0; ic < kRatio; ++ic, pOut += kNChannel)
+                for (auto ic = 0; ic < kRatio; ++ic)
             #else
-                for (auto ic = c == 1 ? 1 : 0; ic < kRatio; ++ic, pOut += kNChannel)
+                for (auto ic = c == 1 ? 1 : 0; ic < kRatio; ++ic)
             #endif
                 {
                 #if PRECOMPUTE_COEFFS
@@ -119,17 +111,13 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
                     const auto y = float(c * kRatio + ic) / kRatioFloat;
                     CalcCoeff4x4(x - floor(x), y - floor(y), coeffs);
                 #endif
-                    const auto* pInInnerRow = pIn;
                     float sums[kNChannel]{};
-                    for (auto i = 0; i < 4; ++i, pInInnerRow += nCol * kNChannel)
-                    {
-                        const auto* pInInner = pInInnerRow;
-                        for (auto j = 0; j < 4; ++j, pInInner += kNChannel)
+                    for (auto i = 0; i < 4; ++i)
+                        for (auto j = 0; j < 4; ++j)
                             for (auto ch = 0; ch < kNChannel; ++ch)
-                                sums[ch] += coeffs[i][j] * pInInner[ch];
-                    }
+                                sums[ch] += coeffs[i][j] * src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
                     for (int ch = 0; ch < kNChannel; ++ch)
-                        pOut[ch] = static_cast<unsigned char>(sums[ch]);
+                        pRes[((r * kRatio + ir) * nResCol + (c * kRatio + ic)) * kNChannel + ch] = static_cast<unsigned char>(sums[ch]);
                 }
             }
         }

--- a/resize.hpp
+++ b/resize.hpp
@@ -92,6 +92,7 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
 #define LOAD_IN_XMM 1
 #define LOAD_IN_INTRIN 1
 
+    #pragma omp parallel for
     for (auto r = 1; r < nRow - 2; ++r)
     {
         for (auto c = 1; c < nCol - 2; ++c)

--- a/resize.hpp
+++ b/resize.hpp
@@ -235,7 +235,7 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
             {
                 constexpr auto j = 3;
 
-                __m128 xdw0, xdw1, xdw2, xdw3;
+                __m128i xdw0, xdw1, xdw2, xdw3;
                 LoadXmm(xdw0, &src.data[((r - 1) * nCol + (c + j - 1)) * kNChannel]);
                 LoadXmm(xdw1, &src.data[((r - 0) * nCol + (c + j - 1)) * kNChannel]);
                 LoadXmm(xdw2, &src.data[((r + 1) * nCol + (c + j - 1)) * kNChannel]);

--- a/resize.hpp
+++ b/resize.hpp
@@ -98,15 +98,14 @@ struct CoeffTable
 
     constexpr decltype(auto) operator[](int ir) const { return (m_Data[ir]); }
 
-    alignas(32) float m_Data[kRatio][kRatio][4][4]{};
+    alignas(64) float m_Data[kRatio][kRatio][4][4]{};
 };
-
-static constexpr CoeffTable kCoeffs;
 
 struct CoeffTableSwizzled
 {
     constexpr CoeffTableSwizzled()
     {
+        constexpr CoeffTable kCoeffs;
         for (auto ir = 0; ir < kRatio; ++ir)
             for (auto i = 0; i < 4; ++i)
                 for (auto j = 0; j < 4; ++j)
@@ -117,7 +116,7 @@ struct CoeffTableSwizzled
 
     constexpr decltype(auto) operator[](int ir) const { return (m_Data[ir]); }
 
-    alignas(32) float m_Data[kRatio][4][4][16]{};
+    alignas(64) float m_Data[kRatio][4][4][16]{};
 };
 
 static constexpr CoeffTableSwizzled kCoeffsSwizzled;
@@ -161,18 +160,7 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
     //  * kRatio <= resRow < nResRow - 2 * kRatio
     // The above also holds for columns
 
-#define PRECOMPUTE_COEFFS 1
 #define SIMPLIFY_START 0
-
-#define LOAD_IN_YMM 1
-#define LOAD_IN_XMM 0
-#define LOAD_IN_INTRIN 1
-
-#define ROTATE_DELTA 0
-#define LOAD_ROTATE_DELTA_INTRIN 0
-
-#define LOAD_DELTA_INTRIN 1
-#define LOAD_DELTA_CP_INTRIN 1
 
     PROF_SCOPED_MARKER("WorkLoop");
 
@@ -184,171 +172,59 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
         alignas(32) float in012[4][4][16];
         {
             PROF_SCOPED_MARKER("LoadInput");
-        #if LOAD_IN_INTRIN
-            #if LOAD_IN_YMM
-                //const auto ydw00 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 0]);
-                //const auto xdw01 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 8]);
-                //const auto ydw10 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 0]);
-                //const auto xdw11 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 8]);
-                //const auto ydw20 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 0]);
-                //const auto xdw21 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 8]);
-                //const auto ydw30 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 0]);
-                //const auto xdw31 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 8]);
 
-                #define GET_SW0(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_1, _0, _2, _1, _0, _2, _1, _0))
-                #define GET_SW1(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_0, _2, _1, _0, _2, _1, _0, _2))
+            //const auto ydw00 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 0]);
+            //const auto xdw01 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 8]);
+            //const auto ydw10 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 0]);
+            //const auto xdw11 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 8]);
+            //const auto ydw20 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 0]);
+            //const auto xdw21 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 8]);
+            //const auto ydw30 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 0]);
+            //const auto xdw31 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 8]);
 
-                #define MAKE_SW(i) \
-                    const auto ydw##i##0 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + i - 1) * nCol + (1 - 1)) * kNChannel + 0]); \
-                    const auto xdw##i##1 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + i - 1) * nCol + (1 - 1)) * kNChannel + 8]); \
-                    const auto yf##i##0 = _mm256_cvtepi32_ps(ydw##i##0);                      /* 00 01 02 10 11 12 20 21 */ \
-                    const auto yf##i##1 = _mm256_castps128_ps256(_mm_cvtepi32_ps(xdw##i##1)); /* 22 30 31 32 ?? ?? ?? ?? */ \
-                    const auto yf##i##2 = _mm256_blend_ps(yf##i##0, yf##i##1, 0b00001111);    /* 22 ?? ?? ?? ?? ?? 20 21 */ \
-                    const auto ysw##i##00 = GET_SW0(yf##i##0, 2, 1, 0); \
-                    const auto ysw##i##01 = GET_SW1(yf##i##0, 2, 1, 0); \
-                    const auto ysw##i##10 = GET_SW0(yf##i##0, 5, 4, 3); \
-                    const auto ysw##i##11 = GET_SW1(yf##i##0, 5, 4, 3); \
-                    const auto ysw##i##20 = GET_SW0(yf##i##2, 0, 7, 6); \
-                    const auto ysw##i##21 = GET_SW1(yf##i##2, 0, 7, 6); \
-                    const auto ysw##i##30 = GET_SW0(yf##i##2, 3, 2, 1); \
-                    const auto ysw##i##31 = GET_SW1(yf##i##2, 3, 2, 1); \
-                    _mm256_store_ps(&in012[i][0][0], ysw##i##00); \
-                    _mm256_store_ps(&in012[i][0][8], ysw##i##01); \
-                    _mm256_store_ps(&in012[i][1][0], ysw##i##10); \
-                    _mm256_store_ps(&in012[i][1][8], ysw##i##11); \
-                    _mm256_store_ps(&in012[i][2][0], ysw##i##20); \
-                    _mm256_store_ps(&in012[i][2][8], ysw##i##21); \
-                    _mm256_store_ps(&in012[i][3][0], ysw##i##30); \
-                    _mm256_store_ps(&in012[i][3][8], ysw##i##31);
+            #define GET_SW0(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_1, _0, _2, _1, _0, _2, _1, _0))
+            #define GET_SW1(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_0, _2, _1, _0, _2, _1, _0, _2))
 
-                MAKE_SW(0);
-                MAKE_SW(1);
-                MAKE_SW(2);
-                MAKE_SW(3);
+            #define MAKE_SW(i) \
+                const auto ydw##i##0 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + i - 1) * nCol + (1 - 1)) * kNChannel + 0]); \
+                const auto xdw##i##1 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + i - 1) * nCol + (1 - 1)) * kNChannel + 8]); \
+                const auto yf##i##0 = _mm256_cvtepi32_ps(ydw##i##0);                      /* 00 01 02 10 11 12 20 21 */ \
+                const auto yf##i##1 = _mm256_castps128_ps256(_mm_cvtepi32_ps(xdw##i##1)); /* 22 30 31 32 ?? ?? ?? ?? */ \
+                const auto yf##i##2 = _mm256_blend_ps(yf##i##0, yf##i##1, 0b00001111);    /* 22 ?? ?? ?? ?? ?? 20 21 */ \
+                const auto ysw##i##00 = GET_SW0(yf##i##0, 2, 1, 0); \
+                const auto ysw##i##01 = GET_SW1(yf##i##0, 2, 1, 0); \
+                const auto ysw##i##10 = GET_SW0(yf##i##0, 5, 4, 3); \
+                const auto ysw##i##11 = GET_SW1(yf##i##0, 5, 4, 3); \
+                const auto ysw##i##20 = GET_SW0(yf##i##2, 0, 7, 6); \
+                const auto ysw##i##21 = GET_SW1(yf##i##2, 0, 7, 6); \
+                const auto ysw##i##30 = GET_SW0(yf##i##2, 3, 2, 1); \
+                const auto ysw##i##31 = GET_SW1(yf##i##2, 3, 2, 1); \
+                _mm256_store_ps(&in012[i][0][0], ysw##i##00); \
+                _mm256_store_ps(&in012[i][0][8], ysw##i##01); \
+                _mm256_store_ps(&in012[i][1][0], ysw##i##10); \
+                _mm256_store_ps(&in012[i][1][8], ysw##i##11); \
+                _mm256_store_ps(&in012[i][2][0], ysw##i##20); \
+                _mm256_store_ps(&in012[i][2][8], ysw##i##21); \
+                _mm256_store_ps(&in012[i][3][0], ysw##i##30); \
+                _mm256_store_ps(&in012[i][3][8], ysw##i##31);
 
-                #undef GET_SW0
-                #undef GET_SW1
-                #undef MAKE_SW
-            #elif LOAD_IN_XMM
-                const auto xdw00 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw01 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 4]);
-                const auto xdw02 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (1 - 1)) * kNChannel + 8]);
-                const auto xdw10 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw11 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 4]);
-                const auto xdw12 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (1 - 1)) * kNChannel + 8]);
-                const auto xdw20 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw21 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 4]);
-                const auto xdw22 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (1 - 1)) * kNChannel + 8]);
-                const auto xdw30 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 0]);
-                const auto xdw31 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 4]);
-                const auto xdw32 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (1 - 1)) * kNChannel + 8]);
-                const auto xf00 = _mm_cvtepi32_ps(xdw00); // 000 001 002 010
-                const auto xf01 = _mm_cvtepi32_ps(xdw01); // 011 012 020 021
-                const auto xf02 = _mm_cvtepi32_ps(xdw02); // 022 030 031 032
-                const auto xf10 = _mm_cvtepi32_ps(xdw10); // 100 101 102 110
-                const auto xf11 = _mm_cvtepi32_ps(xdw11); // 111 112 120 121
-                const auto xf12 = _mm_cvtepi32_ps(xdw12); // 122 130 131 132
-                const auto xf20 = _mm_cvtepi32_ps(xdw20); // 200 201 202 210
-                const auto xf21 = _mm_cvtepi32_ps(xdw21); // 211 212 220 221
-                const auto xf22 = _mm_cvtepi32_ps(xdw22); // 222 230 231 232
-                const auto xf30 = _mm_cvtepi32_ps(xdw30); // 300 301 302 310
-                const auto xf31 = _mm_cvtepi32_ps(xdw31); // 311 312 320 321
-                const auto xf32 = _mm_cvtepi32_ps(xdw32); // 322 330 331 332
+            MAKE_SW(0);
+            MAKE_SW(1);
+            MAKE_SW(2);
+            MAKE_SW(3);
 
-                #define MAKE_SW_(i, j, _2, _1, _0) \
-                    const auto xsw##i##j##0 = _mm_permute_ps(xraw##i##j, _MM_SHUFFLE(_0, _2, _1, _0)); /* 00 01 02 00 */ \
-                    const auto xsw##i##j##1 = _mm_permute_ps(xraw##i##j, _MM_SHUFFLE(_1, _0, _2, _1)); /* 01 02 00 01 */ \
-                    const auto xsw##i##j##2 = _mm_permute_ps(xraw##i##j, _MM_SHUFFLE(_2, _1, _0, _2)); /* 02 00 01 02 */ \
-                    _mm_store_ps(&in012[i][j][ 0], xsw##i##j##0); \
-                    _mm_store_ps(&in012[i][j][ 4], xsw##i##j##1); \
-                    _mm_store_ps(&in012[i][j][ 8], xsw##i##j##2); \
-                    _mm_store_ps(&in012[i][j][12], xsw##i##j##0);
-                #define MAKE_SW(i) \
-                    const auto xraw##i##0 = xf##i##0;                                 /* 00 01 02 ?? */ \
-                    const auto xraw##i##1 = _mm_blend_ps(xf##i##0, xf##i##1, 0b0011); /* 11 12 ?? 10 */ \
-                    const auto xraw##i##2 = _mm_blend_ps(xf##i##1, xf##i##2, 0b0011); /* 22 ?? 20 21 */ \
-                    const auto xraw##i##3 = xf##i##2;                                 /* ?? 30 31 32 */ \
-                    MAKE_SW_(i, 0, 2, 1, 0) \
-                    MAKE_SW_(i, 1, 1, 0, 3) \
-                    MAKE_SW_(i, 2, 0, 3, 2) \
-                    MAKE_SW_(i, 3, 3, 2, 1)
-
-                MAKE_SW(0);
-                MAKE_SW(1);
-                MAKE_SW(2);
-                MAKE_SW(3);
-
-                #undef MAKE_SW_
-                #undef MAKE_SW
-            #else
-                alignas(32) float in[4][4][kNChannel];
-                for (auto i = 0; i < 4; ++i)
-                    for (auto j = 0; j < 4; ++j)
-                        for (auto ch = 0; ch < kNChannel; ++ch)
-                            in[i][j][ch] = src.data[((r + i - 1) * nCol + (1 + j - 1)) * kNChannel + ch];
-                for (auto i = 0; i < 4; ++i)
-                    for (auto j = 0; j < 4; ++j)
-                        for (auto ic = 0; ic < kRatio; ++ic)
-                            for (auto ch = 0; ch < kNChannel; ++ch)
-                                in012[i][j][ic * kNChannel + ch] = in[i][j][ch];
-            #endif
-        #else
-            for (auto i = 0; i < 4; ++i)
-                for (auto j = 0; j < 4; ++j)
-                    for (auto ic = 0; ic < kRatio; ++ic)
-                        for (auto ch = 0; ch < kNChannel; ++ch)
-                            in012[i][j][ic * kNChannel + ch] = src.data[((r + i - 1) * nCol + (1 + j - 1)) * kNChannel + ch];
-        #endif
+            #undef GET_SW0
+            #undef GET_SW1
+            #undef MAKE_SW
         }
 
-        // TODO: Consider rotate delta by row instead of column, which requires transpose.
-        //       Also find a way to effeciently load delta
         for (auto c = 1; c < nCol - 2; ++c)
         {
             //PROF_SCOPED_MARKER("SourceColumn");
             if (c > 1)
             {
                 constexpr auto j = 3;
-            #if ROTATE_DELTA
-                const auto j_ = (c + 2) & 3;
-                #if LOAD_ROTATE_DELTA_INTRIN
-                    //const auto xdw0 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c + j - 1)) * kNChannel]);
-                    //const auto xdw1 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c + j - 1)) * kNChannel]);
-                    //const auto xdw2 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c + j - 1)) * kNChannel]);
-                    //const auto xdw3 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c + j - 1)) * kNChannel]);
-                    //const auto xf0 = _mm_cvtepi32_ps(xdw0);
-                    //const auto xf1 = _mm_cvtepi32_ps(xdw1);
-                    //const auto xf2 = _mm_cvtepi32_ps(xdw2);
-                    //const auto xf3 = _mm_cvtepi32_ps(xdw3);
-                    #define MAKE_SW(i) \
-                        const auto xdw##i = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel]); \
-                        const auto xf0##i = _mm_cvtepi32_ps(xdw0); \
-                        const auto xsw##i##0 = _mm_permute_ps(xf##i, _MM_SHUFFLE(0, 2, 1, 0)); /* 00 01 02 00 */ \
-                        const auto xsw##i##1 = _mm_permute_ps(xf##i, _MM_SHUFFLE(1, 0, 2, 1)); /* 01 02 00 01 */ \
-                        const auto xsw##i##2 = _mm_permute_ps(xf##i, _MM_SHUFFLE(2, 1, 0, 2)); /* 02 00 01 02 */ \
-                        _mm_store_ps(&in012[i][j_][ 0], xsw##i##0); \
-                        _mm_store_ps(&in012[i][j_][ 4], xsw##i##1); \
-                        _mm_store_ps(&in012[i][j_][ 8], xsw##i##2); \
-                        _mm_store_ps(&in012[i][j_][12], xsw##i##0);
 
-                    MAKE_SW(0);
-                    MAKE_SW(1);
-                    MAKE_SW(2);
-                    MAKE_SW(3);
-
-                    #undef MAKE_SW
-                #else
-                    alignas(32) float in[4][kNChannel];
-                    for (auto i = 0; i < 4; ++i)
-                        for (auto ch = 0; ch < kNChannel; ++ch)
-                            in[i][ch] = src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
-                    for (auto i = 0; i < 4; ++i)
-                        for (auto ic = 0; ic < kRatio; ++ic)
-                            for (auto ch = 0; ch < kNChannel; ++ch)
-                                in012[i][j_][ic * kNChannel + ch] = in[i][ch];
-                #endif
-            // TODO: Change this macro
-            #elif LOAD_DELTA_INTRIN
                 const auto xdw0 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c + j - 1)) * kNChannel]);
                 const auto xdw1 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c + j - 1)) * kNChannel]);
                 const auto xdw2 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c + j - 1)) * kNChannel]);
@@ -384,30 +260,10 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
                 MAKE_SW(3);
 
                 #undef MAKE_SW
-            #else
-                alignas(32) float in[4][kNChannel];
-                for (auto i = 0; i < 4; ++i)
-                    for (auto ch = 0; ch < kNChannel; ++ch)
-                        in[i][ch] = src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
-                for (auto i = 0; i < 4; ++i)
-                {
-                #if LOAD_DELTA_CP_INTRIN
-                    for (auto j = 0; j < 3; ++j)
-                    {
-                        _mm256_store_ps(&in012[i][j][0], _mm256_load_ps(&in012[i][j + 1][0]));
-                        _mm256_store_ps(&in012[i][j][8], _mm256_load_ps(&in012[i][j + 1][8]));
-                    }
-                #else
-                    __builtin_memmove(&in012[i][0], &in012[i][1], 3 * 16 * sizeof(float));
-                #endif
-                    for (auto ic = 0; ic < kRatio; ++ic)
-                        for (auto ch = 0; ch < kNChannel; ++ch)
-                            in012[i][j][ic * kNChannel + ch] = in[i][ch];
-                }
-            #endif
             }
 
             //PROF_SCOPED_MARKER("YieldTile");
+
         //#if SIMPLIFY_START
         //    for (auto ir = 0; ir < kRatio; ++ir)
         //#else
@@ -428,13 +284,8 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
                 for (auto i = 0; i < 4; ++i)
                     for (auto j = 0; j < 4; ++j)
                     {
-                    #if ROTATE_DELTA
-                        yf0 = _mm256_fmadd_ps(_mm256_load_ps(&coeffs[i][j][0]), _mm256_load_ps(&in012[i][(c + j - 1) & 3][0]), yf0);
-                        yf1 = _mm256_fmadd_ps(_mm256_load_ps(&coeffs[i][j][8]), _mm256_load_ps(&in012[i][(c + j - 1) & 3][8]), yf1);
-                    #else
                         yf0 = _mm256_fmadd_ps(_mm256_load_ps(&coeffs[i][j][0]), _mm256_load_ps(&in012[i][j][0]), yf0);
                         yf1 = _mm256_fmadd_ps(_mm256_load_ps(&coeffs[i][j][8]), _mm256_load_ps(&in012[i][j][8]), yf1);
-                    #endif
                     }
 
                 const auto ydw0 = _mm256_cvttps_epi32(yf0);

--- a/resize.hpp
+++ b/resize.hpp
@@ -13,7 +13,8 @@ constexpr float WeightCoeff(float x, float a)
     return 0.0;
 }
 
-constexpr void CalcCoeff4x4(float u, float v, float outCoeff[4][4]) {
+constexpr void CalcCoeff4x4(float u, float v, float outCoeff[4][4])
+{
     constexpr float a = -0.5f;
 
     u += 1.0f;
@@ -83,38 +84,8 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
     //  * kRatio <= resRow < nResRow - 2 * kRatio
     // The above also holds for columns
 
-#define PRECOMPUTE_COEFFS 0
+#define PRECOMPUTE_COEFFS 1
 #define SIMPLIFY_START 0
-
-#if 0
-    auto SampleBicubic = [&src, nCol](const float coeffs[4][4], int r, int c, int ch) -> unsigned char
-    {
-        auto sum = 0.0f;
-        const auto* in = &src.data[((r - 1) * nCol + c - 1) * kNChannel + ch];
-        for (auto i = 0; i < 4; ++i, in += nCol * kNChannel)
-            for (auto j = 0; j < 4; ++j)
-                sum += coeffs[i][j] * in[j * kNChannel];
-        return static_cast<unsigned char>(sum);
-    };
-
-    auto ProcessCell = [&SampleBicubic, nResCol, pRes](int r, int ir, int c, int ic)
-    {
-        const auto resRow = r * kRatio + ir;
-        const auto resCol = c * kRatio + ic;
-        const auto resIdx = (resRow * nResCol + resCol) * kNChannel;
-    #if PRECOMPUTE_COEFFS
-        const auto& coeffs = kCoeffs.m_Coeffs[ir][ic];
-    #else
-        float coeffs[4][4];
-        const auto x = float(r * kRatio + ir) / kRatioFloat;
-        const auto y = float(c * kRatio + ic) / kRatioFloat;
-        CalcCoeff4x4(x - floor(x), y - floor(y), coeffs);
-    #endif
-
-        for (int ch = 0; ch < kNChannel; ++ch)
-            pRes[resIdx + ch] = SampleBicubic(coeffs, r, c, ch);
-    };
-#endif
 
     const auto* pInRow = src.data;
 #if SIMPLIFY_START

--- a/resize.hpp
+++ b/resize.hpp
@@ -110,8 +110,9 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
 
 #define PRECOMPUTE_COEFFS 1
 #define SIMPLIFY_START 0
-#define LOAD_IN_YMM 0
-#define LOAD_IN_XMM 1
+
+#define LOAD_IN_YMM 1
+#define LOAD_IN_XMM 0
 #define LOAD_IN_INTRIN 1
 
     #pragma omp parallel for
@@ -119,12 +120,123 @@ RGBImage ResizeImage(RGBImage src, float ratio) {
     {
         for (auto c = 1; c < nCol - 2; ++c)
         {
-            alignas(32) float in012[4][4][16]{};
-            for (int i = 0; i < 4; ++i)
-                for (auto j = 0; j < 4; ++j)
-                    for (auto ic = 0; ic < kRatio; ++ic)
-                        for (auto ch = 0; ch < kNChannel; ++ch)
-                            in012[i][j][ic * kNChannel + ch] = src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
+            alignas(32) float in012[4][4][16];
+            {
+            #if LOAD_IN_INTRIN
+                #if LOAD_IN_YMM
+                    const auto ydw00 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw01 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 1) * nCol + (c - 1)) * kNChannel + 8]);
+                    const auto ydw10 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw11 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r - 0) * nCol + (c - 1)) * kNChannel + 8]);
+                    const auto ydw20 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw21 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 1) * nCol + (c - 1)) * kNChannel + 8]);
+                    const auto ydw30 = _mm256_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw31 = _mm_cvtepu8_epi32(   *(const __m128i*)&src.data[((r + 2) * nCol + (c - 1)) * kNChannel + 8]);
+
+                    #define GET_SW0(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_1, _0, _2, _1, _0, _2, _1, _0))
+                    #define GET_SW1(y, _2, _1, _0) _mm256_permutevar8x32_ps(y, _mm256_set_epi32(_0, _2, _1, _0, _2, _1, _0, _2))
+
+                    #define MAKE_SW(i) \
+                        const auto yf##i##0 = _mm256_cvtepi32_ps(ydw##i##0);                      /* 00 01 02 10 11 12 20 21 */ \
+                        const auto yf##i##1 = _mm256_castps128_ps256(_mm_cvtepi32_ps(xdw##i##1)); /* 22 30 31 32 ?? ?? ?? ?? */ \
+                        const auto yf##i##2 = _mm256_blend_ps(yf##i##0, yf##i##1, 0b00001111);    /* 22 ?? ?? ?? ?? ?? 20 21 */ \
+                        const auto ysw##i##00 = GET_SW0(yf##i##0, 2, 1, 0); \
+                        const auto ysw##i##01 = GET_SW1(yf##i##0, 2, 1, 0); \
+                        const auto ysw##i##10 = GET_SW0(yf##i##0, 5, 4, 3); \
+                        const auto ysw##i##11 = GET_SW1(yf##i##0, 5, 4, 3); \
+                        const auto ysw##i##20 = GET_SW0(yf##i##2, 0, 7, 6); \
+                        const auto ysw##i##21 = GET_SW1(yf##i##2, 0, 7, 6); \
+                        const auto ysw##i##30 = GET_SW0(yf##i##2, 3, 2, 1); \
+                        const auto ysw##i##31 = GET_SW1(yf##i##2, 3, 2, 1); \
+                        _mm256_store_ps(&in012[i][0][0], ysw##i##00); \
+                        _mm256_store_ps(&in012[i][0][8], ysw##i##01); \
+                        _mm256_store_ps(&in012[i][1][0], ysw##i##10); \
+                        _mm256_store_ps(&in012[i][1][8], ysw##i##11); \
+                        _mm256_store_ps(&in012[i][2][0], ysw##i##20); \
+                        _mm256_store_ps(&in012[i][2][8], ysw##i##21); \
+                        _mm256_store_ps(&in012[i][3][0], ysw##i##30); \
+                        _mm256_store_ps(&in012[i][3][8], ysw##i##31);
+
+                    MAKE_SW(0);
+                    MAKE_SW(1);
+                    MAKE_SW(2);
+                    MAKE_SW(3);
+
+                    #undef GET_SW0
+                    #undef GET_SW1
+                    #undef MAKE_SW
+                #elif LOAD_IN_XMM
+                    const auto xdw00 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw01 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c - 1)) * kNChannel + 4]);
+                    const auto xdw02 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 1) * nCol + (c - 1)) * kNChannel + 8]);
+                    const auto xdw10 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw11 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c - 1)) * kNChannel + 4]);
+                    const auto xdw12 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r - 0) * nCol + (c - 1)) * kNChannel + 8]);
+                    const auto xdw20 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw21 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c - 1)) * kNChannel + 4]);
+                    const auto xdw22 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 1) * nCol + (c - 1)) * kNChannel + 8]);
+                    const auto xdw30 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c - 1)) * kNChannel + 0]);
+                    const auto xdw31 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c - 1)) * kNChannel + 4]);
+                    const auto xdw32 = _mm_cvtepu8_epi32(*(const __m128i*)&src.data[((r + 2) * nCol + (c - 1)) * kNChannel + 8]);
+                    const auto xf00 = _mm_cvtepi32_ps(xdw00); // 000 001 002 010
+                    const auto xf01 = _mm_cvtepi32_ps(xdw01); // 011 012 020 021
+                    const auto xf02 = _mm_cvtepi32_ps(xdw02); // 022 030 031 032
+                    const auto xf10 = _mm_cvtepi32_ps(xdw10); // 100 101 102 110
+                    const auto xf11 = _mm_cvtepi32_ps(xdw11); // 111 112 120 121
+                    const auto xf12 = _mm_cvtepi32_ps(xdw12); // 122 130 131 132
+                    const auto xf20 = _mm_cvtepi32_ps(xdw20); // 200 201 202 210
+                    const auto xf21 = _mm_cvtepi32_ps(xdw21); // 211 212 220 221
+                    const auto xf22 = _mm_cvtepi32_ps(xdw22); // 222 230 231 232
+                    const auto xf30 = _mm_cvtepi32_ps(xdw30); // 300 301 302 310
+                    const auto xf31 = _mm_cvtepi32_ps(xdw31); // 311 312 320 321
+                    const auto xf32 = _mm_cvtepi32_ps(xdw32); // 322 330 331 332
+
+                    #define MAKE_SW_(i, j, _2, _1, _0) \
+                        const auto xsw##i##j##0 = _mm_permute_ps(xraw##i##j, _MM_SHUFFLE(_0, _2, _1, _0)); /* 00 01 02 00 */ \
+                        const auto xsw##i##j##1 = _mm_permute_ps(xraw##i##j, _MM_SHUFFLE(_1, _0, _2, _1)); /* 01 02 00 01 */ \
+                        const auto xsw##i##j##2 = _mm_permute_ps(xraw##i##j, _MM_SHUFFLE(_2, _1, _0, _2)); /* 02 00 01 02 */ \
+                        _mm_store_ps(&in012[i][j][ 0], xsw##i##j##0); \
+                        _mm_store_ps(&in012[i][j][ 4], xsw##i##j##1); \
+                        _mm_store_ps(&in012[i][j][ 8], xsw##i##j##2); \
+                        _mm_store_ps(&in012[i][j][12], xsw##i##j##0);
+                    #define MAKE_SW(i) \
+                        const auto xraw##i##0 = xf##i##0;                                 /* 00 01 02 ?? */ \
+                        const auto xraw##i##1 = _mm_blend_ps(xf##i##0, xf##i##1, 0b0011); /* 11 12 ?? 10 */ \
+                        const auto xraw##i##2 = _mm_blend_ps(xf##i##1, xf##i##2, 0b0011); /* 22 ?? 20 21 */ \
+                        const auto xraw##i##3 = xf##i##2;                                 /* ?? 30 31 32 */ \
+                        MAKE_SW_(i, 0, 2, 1, 0) \
+                        MAKE_SW_(i, 1, 1, 0, 3) \
+                        MAKE_SW_(i, 2, 0, 3, 2) \
+                        MAKE_SW_(i, 3, 3, 2, 1)
+
+                    MAKE_SW(0);
+                    MAKE_SW(1);
+                    MAKE_SW(2);
+                    MAKE_SW(3);
+
+                    #undef MAKE_SW_
+                    #undef MAKE_SW
+                #else
+                    alignas(32) float in[4][4][kNChannel];
+                    for (auto i = 0; i < 4; ++i)
+                        for (auto j = 0; j < 4; ++j)
+                            for (auto ch = 0; ch < kNChannel; ++ch)
+                                in[i][j][ch] = src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
+                    for (auto i = 0; i < 4; ++i)
+                        for (auto j = 0; j < 4; ++j)
+                            for (auto ic = 0; ic < kRatio; ++ic)
+                                for (auto ch = 0; ch < kNChannel; ++ch)
+                                    in012[i][j][ic * kNChannel + ch] = in[i][j][ch];
+                #endif
+            #else
+                for (int i = 0; i < 4; ++i)
+                    for (auto j = 0; j < 4; ++j)
+                        for (auto ic = 0; ic < kRatio; ++ic)
+                            for (auto ch = 0; ch < kNChannel; ++ch)
+                                in012[i][j][ic * kNChannel + ch] = src.data[((r + i - 1) * nCol + (c + j - 1)) * kNChannel + ch];
+            #endif
+            }
+
 
         #if SIMPLIFY_START
             for (auto ir = 0; ir < kRatio; ++ir)


### PR DESCRIPTION
使用HUST.PNG的情况下，
|      |       |
|-----|-------|
| 原版 | 4347ms |
| 优化后单线程 | 65ms |
| 优化后12线程 | 19ms |
| 优化后24线程 | 17ms |

通过环境变量`OMP_NUM_THREADS`控制线程数。